### PR TITLE
Gaussian masking tweak

### DIFF
--- a/gabor_fn.m
+++ b/gabor_fn.m
@@ -1,4 +1,4 @@
-function [gb,x,y,x_theta,y_theta]=gabor_fn(theta,lambda,psi,gamma,x0,y0)
+function gb=gabor_fn(theta,lambda,psi,gamma,x0,y0)
 % produce a gabor wavelet for the given sf,angle,phase,posi
 if nargin == 4
     x0=0;
@@ -22,7 +22,9 @@ y_theta=-x*sin(theta)+y*cos(theta);
 gaussian_mask = exp(-.5*(x_theta.^2/sigma_x^2+y_theta.^2/sigma_y^2));
 gaussian_mask(gaussian_mask < (max(gaussian_mask(:))*0.01)) = 0;
 
-gb = gaussian_mask .*cos(2*pi/lambda*x_theta+psi);
+sinusoid = cos(2*pi/lambda*x_theta+psi);
+
+gb = gaussian_mask .* sinusoid;
 %size(x);
 %imshow(gb,[]);
 end

--- a/gabor_fn.m
+++ b/gabor_fn.m
@@ -1,4 +1,4 @@
-function gb=gabor_fn(theta,lambda,psi,gamma,x0,y0)
+function [gb,x,y,x_theta,y_theta]=gabor_fn(theta,lambda,psi,gamma,x0,y0)
 % produce a gabor wavelet for the given sf,angle,phase,posi
 if nargin == 4
     x0=0;
@@ -19,8 +19,10 @@ y=y-y0;
 x_theta=x*cos(theta)+y*sin(theta);
 y_theta=-x*sin(theta)+y*cos(theta);
 
-gb=exp(-.5*(x_theta.^2/sigma_x^2+y_theta.^2/sigma_y^2)).*cos(2*pi/lambda*x_theta+psi);
-gb(gb<10^-5&gb>-10^-5)=0;
+gaussian_mask = exp(-.5*(x_theta.^2/sigma_x^2+y_theta.^2/sigma_y^2));
+gaussian_mask(gaussian_mask < (max(gaussian_mask(:))*0.01)) = 0;
+
+gb = gaussian_mask .*cos(2*pi/lambda*x_theta+psi);
 %size(x);
 %imshow(gb,[]);
 end


### PR DESCRIPTION
First, thanks for making this code available - very interesting!
I noticed that there is a minor issue (/difference compared the original publication) with how the thresholding on the gabors is done. 

In the original paper:
>Wavelets are truncated to lie within the bounds of the image, and are restricted in spatial extent by setting to zero the portions of the masks whose values are less than 0.01 of the peak value.

Whereas in the code as it stands it acts upon the gabor itself, rather than just the gaussian mask. See comparison below (I temporarily subbed out the `=0` for `=NaN` to make these visualizations).

![gauss_prev](https://user-images.githubusercontent.com/3739866/88467381-87693980-cea4-11ea-81a2-f19ff9594321.png)
![gauss_circ](https://user-images.githubusercontent.com/3739866/88467382-87693980-cea4-11ea-934b-72b7f0157eaf.png)

I have not yet tested whether this change has any impact on the final results.

I also separated out the different elements of the gabor to make the code a little more readable.
